### PR TITLE
follow pytest convention to actually execute some tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,0 @@
-from cee_syslog_handler import get_fields
-
-class Record(object):
-    pass
-
-def test_get_fields_empty():
-    record =  Record()
-    message_dict = get_fields({}, record)
-    assert message_dict == {}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,9 @@
+from cee_syslog_handler import get_fields
+
+class Record(object):
+    pass
+
+def test_get_fields_empty():
+    record =  Record()
+    message_dict = get_fields({}, record)
+    assert message_dict == {}


### PR DESCRIPTION
`python setup.py test` didn't find any tests. As a convention pytest searches for files starting with `test`. So a simple renaming did the job.
