### PR TITLE
Extended type support

### DIFF
--- a/cee_syslog_handler/__init__.py
+++ b/cee_syslog_handler/__init__.py
@@ -80,10 +80,11 @@ def get_fields(message_dict, record):
 
     for key, value in record.__dict__.items():
         if key not in skip_fields and not key.startswith('_'):
-            if isinstance(value, basestring):
-                message_dict['_%s' % key] = value
-            else:
-                message_dict['_%s' % key] = repr(value)
+            try:
+                message_dict['_%s' % key] = float(value)
+            except ValueError:
+                message_dict['_%s' % key] = str(value)
+
     return message_dict
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,0 @@
-from cee_syslog_handler import get_fields
-
-class Record(object):
-    pass
-
-def test_get_fields_empty():
-    record =  Record()
-    message_dict = get_fields({}, record)
-    assert message_dict == {}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -19,9 +19,22 @@ def test_get_fields_empty():
 
 def test_string_types():
     check_single_value('some_text')
+    check_single_value(u'some_text')
 
-def test_float_types():
+def test_numeric_types():
+    pi = 3.1415
+
+    class SomeType(object):
+        def __init__(self):
+            self._value = pi
+
+        def __float__(self):
+            return self._value
+
+        def __eq__(self, value):
+            return float(value) == self._value
+
     check_single_value(1.1)
-
-def test_int_types():    
     check_single_value(1)
+    assert float(SomeType()) == pi
+    check_single_value(SomeType())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,9 @@
+from cee_syslog_handler import get_fields
+
+class Record(object):
+    pass
+
+def test_get_fields_empty():
+    record =  Record()
+    message_dict = get_fields({}, record)
+    assert message_dict == {}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,27 @@
 from cee_syslog_handler import get_fields
 
+
 class Record(object):
-    pass
+    def __init__(self, value=None):
+        if value:
+            self.some_column = value 
+
+
+def check_single_value(value):
+    record = Record(value)
+    message_dict = get_fields({}, record)
+    assert message_dict == {'_some_column': value}
 
 def test_get_fields_empty():
     record =  Record()
     message_dict = get_fields({}, record)
     assert message_dict == {}
+
+def test_string_types():
+    check_single_value('some_text')
+
+def test_float_types():
+    check_single_value(1.1)
+
+def test_int_types():    
+    check_single_value(1)


### PR DESCRIPTION
Issuing values via the `extra` keyword in the logging method is a great way of enhancing log messages in a structured way. Unfortunately, all values are converted to strings.
This pull request modifies the handler in such a way that numeric values are not converted to strings. 

For the feature unit tests have been added. And the possibility to execute the tests with `python setup.py test` has been restored. 
