### PR TITLE
Underscore fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+Changelog
+=========
+
+0.3.3
+-----
+
+*   Custom log record fields with leading underscore are now contained in
+    the log message. In case the (otherwise) same custom field exists both
+    with and without leading underscore, the one with leading underscore has
+    precedence. 

--- a/cee_syslog_handler/__init__.py
+++ b/cee_syslog_handler/__init__.py
@@ -112,7 +112,9 @@ def _custom_key(key):
 
 #See http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
 def get_fields(message_dict, record):
-    for key, value in record.__dict__.items():
+    fields = record.__dict__
+    for key in sorted(fields.keys(), reverse=True):
+        value = fields[key]
         if key not in _SKIPPED_FIELDS:
             message_dict[_custom_key(key)] = _to_supported_output_type(value)
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ class PyTest(TestCommand):
         params = {"args": self.test_args}
         if self.cov:
             params["args"] += self.cov
-            params["plugins"] = ["cov"]
         if self.junitxml:
             params["args"] += self.junitxml
         errno = pytest.main(**params)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -33,6 +33,16 @@ def test_custom_field_with_leading_underscore():
     assert '"_custom_field": "custom value"' in handler.format(record)
 
 
+def test_custom_fields_with_underscores_have_precendence():
+    record = makeLogRecord( {'name':'my.package.logger'} )
+    record.foo = "should not appear in output"
+    record._foo = "has precedence"
+    handler = CeeSysLogHandler()
+
+    assert 'has precedence' in handler.format(record)
+    assert 'should not appear in output' not in handler.format(record)
+
+
 def test_id_field_not_supported():
     record = makeLogRecord( {'name':'my.package.logger'} )
     record.id = "custom value"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -16,3 +16,40 @@ def test_custom_facility():
     assert '"facility": "my.custom.facility"' in handler.format(record)
     assert '"_logger": "my.package.logger"' in handler.format(record)
 
+
+def test_custom_field():
+    record = makeLogRecord( {'name':'my.package.logger'} )
+    record.custom_field = "custom value"
+    handler = CeeSysLogHandler()
+
+    assert '"_custom_field": "custom value"' in handler.format(record)
+
+
+def test_custom_field_with_leading_underscore():
+    record = makeLogRecord( {'name':'my.package.logger'} )
+    record._custom_field = "custom value"
+    handler = CeeSysLogHandler()
+
+    assert '"_custom_field": "custom value"' in handler.format(record)
+
+
+def test_id_field_not_supported():
+    record = makeLogRecord( {'name':'my.package.logger'} )
+    record.id = "custom value"
+    record._id = "some other value value"
+    handler = CeeSysLogHandler()
+
+    assert '"_id"' not in handler.format(record)
+
+
+class _BadStringRepresentation(object):
+    def __str__(self):
+        raise RuntimeError("I misbehave")
+
+
+def test_custom_field_with_raising_str():
+    record = makeLogRecord( {'name':'my.package.logger'} )
+    record._custom_field = _BadStringRepresentation()
+    handler = CeeSysLogHandler()
+
+    assert '"_custom_field": "value could not be converted to str"' in handler.format(record)


### PR DESCRIPTION
- Support custom fields with leading underscores. Useful for adding custom fields like "_name", which would otherwise clash with standard Python record fields ("name", in this case).
- Fix setup.py by removing bad use of cov plugin
- Refactor get_fields to be more readable
- Improve test coverage
