### PR TITLE
Add redacting regex filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - '2.7'
-  - '3.4'
   - '3.6'
+  - '3.7'
+  - '3.8'
 install:
   - pip install -r requirements_test.txt
   - pip install coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.6.0 (2020-10-13)
+------------------
+*   Add new filter redacting log messages according to a regex.
+
+
 0.5.0 (2017-11-14)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-0.6.0 (2020-10-13)
+0.6.0 (UNRELEASED)
 ------------------
 *   Add new filter redacting log messages according to a regex.
+*   Remove support for Python 2 and Python 3.4.
 
 
 0.5.0 (2017-11-14)

--- a/cee_syslog_handler/__init__.py
+++ b/cee_syslog_handler/__init__.py
@@ -3,19 +3,8 @@ from datetime import datetime
 import json
 import re
 import socket
-import sys
 import traceback
 import logging
-
-
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    string_type = str
-    integer_type = int,
-else:
-    string_type = basestring
-    integer_type = (int, long)
 
 SYSLOG_LEVELS = {
     logging.CRITICAL: 2,
@@ -38,7 +27,7 @@ _STANDARD_FIELDS = set(('args', 'asctime', 'created', 'exc_info', 'exc_text', 'f
 _SKIPPED_FIELDS = _STANDARD_FIELDS | set(('id', '_id'))
 
 
-_SUPPORTED_OUTPUT_TYPES = (string_type, float) + integer_type
+_SUPPORTED_OUTPUT_TYPES = (str, float, int)
 
 
 #see http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
@@ -312,7 +301,7 @@ class RegexRedactFilter(logging.Filter):
         if record.exc_text:
             record.exc_text = self.redact(record.exc_text)
 
-        if hasattr(record, "stack_info") and record.stack_info:
+        if record.stack_info:
             record.msg = record.msg + "\n" \
                          + self.redact(
                             self._formatter.formatStack(record.stack_info))

--- a/cee_syslog_handler/__init__.py
+++ b/cee_syslog_handler/__init__.py
@@ -1,10 +1,10 @@
-from logging.handlers import SysLogHandler, SYSLOG_UDP_PORT
-from datetime import datetime
 import json
+import logging
 import re
 import socket
 import traceback
-import logging
+from datetime import datetime
+from logging.handlers import SYSLOG_UDP_PORT, SysLogHandler
 
 SYSLOG_LEVELS = {
     logging.CRITICAL: 2,
@@ -18,50 +18,75 @@ SYSLOG_LEVELS = {
 # The following fields are standard log record fields according to
 # http://docs.python.org/library/logging.html#logrecord-attributes
 # Hint: exc_text is a cache field used by the logging module
-_STANDARD_FIELDS = set(('args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
-    'funcName', 'levelname', 'levelno', 'lineno', 'module', 'msecs', 'message', 'msg', 'name',
-    'pathname', 'process', 'processName', 'relativeCreated', 'stack_info', 'thread', 'threadName'))
+_STANDARD_FIELDS = set(
+    (
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "message",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+    )
+)
 
 
 # The GELF format does not support "_id" fields
-_SKIPPED_FIELDS = _STANDARD_FIELDS | set(('id', '_id'))
+_SKIPPED_FIELDS = _STANDARD_FIELDS | set(("id", "_id"))
 
 
 _SUPPORTED_OUTPUT_TYPES = (str, float, int)
 
 
-#see http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
+# see http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
 def get_full_message(exc_info, message):
-    return '\n'.join(traceback.format_exception(*exc_info)) if exc_info else message
+    return "\n".join(traceback.format_exception(*exc_info)) if exc_info else message
 
 
-#see http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
-def make_message_dict(record, fqdn, debugging_fields, extra_fields, facility, static_fields):
+# see http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
+def make_message_dict(
+    record, fqdn, debugging_fields, extra_fields, facility, static_fields
+):
     message = record.getMessage()
     message_dict = {
-        'host': fqdn,
-        'short_message': message,
-        'message': get_full_message(record.exc_info, message),
-        'timestamp': record.created,
-        'level': SYSLOG_LEVELS.get(record.levelno, record.levelno),
-        'facility': facility or record.name,
-        'source_facility': facility or record.name,
+        "host": fqdn,
+        "short_message": message,
+        "message": get_full_message(record.exc_info, message),
+        "timestamp": record.created,
+        "level": SYSLOG_LEVELS.get(record.levelno, record.levelno),
+        "facility": facility or record.name,
+        "source_facility": facility or record.name,
     }
 
     if facility is not None:
-        message_dict.update({
-            '_logger': record.name
-        })
+        message_dict.update({"_logger": record.name})
 
     if debugging_fields:
-        message_dict.update({
-            'file': record.pathname,
-            'line': record.lineno,
-            '_function': record.funcName,
-            '_pid': record.process,
-            '_thread_name': record.threadName,
-            '_process_name': record.processName
-        })
+        message_dict.update(
+            {
+                "file": record.pathname,
+                "line": record.lineno,
+                "_function": record.funcName,
+                "_pid": record.process,
+                "_thread_name": record.threadName,
+                "_process_name": record.processName,
+            }
+        )
 
     message_dict.update(static_fields)
 
@@ -76,24 +101,24 @@ def _to_supported_output_type(value):
         try:
             return str(value)
         except:
-            #make logging nothrow
-            return 'value could not be converted to str'
+            # make logging nothrow
+            return "value could not be converted to str"
     else:
         return value
 
 
 def _custom_key(key):
-    if key.startswith('_'):
+    if key.startswith("_"):
         return key
     else:
-        return '_{}'.format(key)
+        return "_{}".format(key)
 
 
 def _sanitize_fields(fields):
     return {_custom_key(k): _to_supported_output_type(v) for k, v in fields.items()}
 
 
-#See http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
+# See http://github.com/hoffmann/graypy/blob/master/graypy/handler.py
 def get_fields(message_dict, record):
     fields = record.__dict__
     unskipped_field_names = set(fields.keys()) - _SKIPPED_FIELDS
@@ -124,11 +149,12 @@ class JsonFormatter(logging.Formatter):
     """
 
     def __init__(
-            self,
-            datefmt='%Y-%m-%dT%H:%M:%S.%f',
-            debugging_fields=True,
-            extra_fields=True,
-            **kwargs):
+        self,
+        datefmt="%Y-%m-%dT%H:%M:%S.%f",
+        debugging_fields=True,
+        extra_fields=True,
+        **kwargs
+    ):
         """
         :param datefmt: The date formatting
         :param debugging_fields: Whether to include file, line number, function, process and thread
@@ -151,9 +177,12 @@ class JsonFormatter(logging.Formatter):
             debugging_fields=self.debugging_fields,
             extra_fields=self.extra_fields,
             facility=None,
-            static_fields=self._static_fields)
+            static_fields=self._static_fields,
+        )
 
-        record["timestamp"] = datetime.fromtimestamp(record["timestamp"]).strftime(self.datefmt)
+        record["timestamp"] = datetime.fromtimestamp(record["timestamp"]).strftime(
+            self.datefmt
+        )
         del record["short_message"]
         del record["source_facility"]
         return json.dumps(record)
@@ -197,13 +226,14 @@ class CeeSysLogHandler(SysLogHandler):
     """
 
     def __init__(
-            self,
-            address=('localhost', SYSLOG_UDP_PORT),
-            socktype=socket.SOCK_DGRAM,
-            debugging_fields=True,
-            extra_fields=True,
-            facility=None,
-            **kwargs):
+        self,
+        address=("localhost", SYSLOG_UDP_PORT),
+        socktype=socket.SOCK_DGRAM,
+        debugging_fields=True,
+        extra_fields=True,
+        facility=None,
+        **kwargs
+    ):
         """
 
         :param address: Address of the syslog server (hostname, port)
@@ -217,9 +247,8 @@ class CeeSysLogHandler(SysLogHandler):
         :param kwargs: Additional static fields to be injected in each message.
         """
         super(CeeSysLogHandler, self).__init__(
-            address,
-            facility=SysLogHandler.LOG_USER,
-            socktype=socktype)
+            address, facility=SysLogHandler.LOG_USER, socktype=socktype
+        )
         self._debugging_fields = debugging_fields
         self._extra_fields = extra_fields
         self._facility = facility
@@ -233,12 +262,12 @@ class CeeSysLogHandler(SysLogHandler):
             self._debugging_fields,
             self._extra_fields,
             self._facility,
-            self._static_fields)
+            self._static_fields,
+        )
         return ": @cee: %s" % json.dumps(message)
 
 
 class NamedCeeLogger(CeeSysLogHandler):
-
     def __init__(self, address, socket_type, name):
         super(NamedCeeLogger, self).__init__(address, socket_type, name=name)
 
@@ -248,6 +277,7 @@ class RegexFilter(logging.Filter):
     This Filter can be used to discard log messages that contain a match of
     a given regular expression.
     """
+
     def __init__(self, filter_regex):
         super(RegexFilter, self).__init__()
         self._pattern = re.compile(filter_regex)
@@ -268,8 +298,8 @@ class RegexRedactFilter(logging.Filter):
     by substituting through a provided regular expression.
     Use with caution: with great power comes great responsibility
     """
-    def __init__(self, filter_regex=None,
-                 replace_string="<redacted>"):
+
+    def __init__(self, filter_regex=None, replace_string="<redacted>"):
         super(RegexRedactFilter, self).__init__()
         self._pattern = re.compile(filter_regex)
         self._replacement = replace_string
@@ -282,9 +312,9 @@ class RegexRedactFilter(logging.Filter):
 
     def filter(self, record):
         message = record.getMessage()
-        if not self._pattern.search(message)\
-                and not (record.exc_info or record.exc_text
-                         or record.stack_info):
+        if not self._pattern.search(message) and not (
+            record.exc_info or record.exc_text or record.stack_info
+        ):
             return True
 
         record.msg = self.redact(message)
@@ -293,17 +323,21 @@ class RegexRedactFilter(logging.Filter):
         if record.exc_info:
             # exc_info is a tuple based on sys.exc_info()
             # (type, value, traceback)
-            record.msg = record.msg + "\n" \
-                         + self.redact(
-                            self._formatter.formatException(record.exc_info))
+            record.msg = (
+                record.msg
+                + "\n"
+                + self.redact(self._formatter.formatException(record.exc_info))
+            )
             record.exc_info = None
 
         if record.exc_text:
             record.exc_text = self.redact(record.exc_text)
 
         if record.stack_info:
-            record.msg = record.msg + "\n" \
-                         + self.redact(
-                            self._formatter.formatStack(record.stack_info))
+            record.msg = (
+                record.msg
+                + "\n"
+                + self.redact(self._formatter.formatStack(record.stack_info))
+            )
             record.stack_info = None
         return True

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,29 @@
 # coding=utf-8
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-with open('README.rst') as f:
+with open("README.rst") as f:
     readme = f.read()
 
 setup(
-    name='cee_syslog_handler',
+    name="cee_syslog_handler",
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
-    packages=find_packages(exclude=['tests']),
-    author='Blue Yonder GmbH',
-    author_email='peter.hoffmann@blue-yonder.com',
-    url='https://github.com/blue-yonder/cee_syslog_handler',
-    description='Python Syslog Logging Handler with CEE Support',
+    setup_requires=["setuptools_scm"],
+    packages=find_packages(exclude=["tests"]),
+    author="Blue Yonder GmbH",
+    author_email="peter.hoffmann@blue-yonder.com",
+    url="https://github.com/blue-yonder/cee_syslog_handler",
+    description="Python Syslog Logging Handler with CEE Support",
     long_description=readme,
-    license='new BSD',
+    license="new BSD",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,24 +4,27 @@ from cee_syslog_handler import get_fields
 class Record(object):
     def __init__(self, value=None):
         if value:
-            self.some_column = value 
+            self.some_column = value
 
 
 def check_single_value(value):
     record = Record(value)
     message_dict = get_fields({}, record)
-    assert message_dict == {'_some_column': value}
+    assert message_dict == {"_some_column": value}
+
 
 def test_get_fields_empty():
-    record =  Record()
+    record = Record()
     message_dict = get_fields({}, record)
     assert message_dict == {}
 
+
 def test_string_types():
-    check_single_value('some_text')
-    check_single_value(u'some_text')
-    check_single_value('1')
-    check_single_value('1.1')
+    check_single_value("some_text")
+    check_single_value(u"some_text")
+    check_single_value("1")
+    check_single_value("1.1")
+
 
 def test_numeric_types():
     check_single_value(1.1)

--- a/tests/test_filter_handler.py
+++ b/tests/test_filter_handler.py
@@ -1,7 +1,7 @@
+import logging
 from logging import makeLogRecord
 
-from cee_syslog_handler import NamedCeeLogger, RegexFilter
-
+from cee_syslog_handler import NamedCeeLogger, RegexFilter, RegexRedactFilter
 
 _DUMMY_HOST = ('localhost', 1337)
 _DUMMY_PROTOCOL = 2
@@ -34,3 +34,181 @@ def test_filter():
 
     handler.handle(makeLogRecord({'msg': 'Eating vegetables is healthy and improves blood metrics'}))
     assert len(handler.emitted_records) == 2 # new record emitted
+
+
+def test_redacting_filter():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+
+    record = makeLogRecord(
+        {
+            'name': 'my.package.logger',
+            'msg': 'Connect by IP 172.24.41.42'
+        }
+    )
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    handler.handle(record)
+
+    assert len(handler.emitted_records) == 1
+    message = handler.emitted_records[0].getMessage()
+    assert string_to_be_redacted not in message
+    assert replace_string in message
+
+
+def test_redact_injected_variables():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+
+    arbitrary_object = SomeClass("some 172.24.41.42 arbitrary object")
+    record = makeLogRecord(
+        {
+            'name': 'my.package.logger',
+            'msg': 'Connect %d by IP %s %s',
+            'args': (42, '172.24.41.42', arbitrary_object)
+        }
+    )
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    handler.handle(record)
+
+    assert len(handler.emitted_records) == 1
+    message = handler.emitted_records[0].getMessage()
+    assert string_to_be_redacted not in message
+    assert replace_string in message
+
+
+def test_redact_exception():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+    logger = logging.getLogger(__name__)
+
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    logger.addHandler(handler)
+
+    arbitrary_object = SomeClass("some 172.24.41.42 arbitrary object")
+
+    try:
+        raise MemoryError(
+            "something bad: ",
+            string_to_be_redacted,
+            arbitrary_object
+        )
+    except MemoryError as e:
+        logger.exception(e)
+
+    assert len(handler.emitted_records) == 1
+    message = handler.emitted_records[0].getMessage()
+    assert string_to_be_redacted not in message
+    assert replace_string in message
+
+
+def test_redact_objects():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+
+    logger = logging.getLogger(__name__)
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    logger.addHandler(handler)
+
+    arbitrary = SomeClass("some message containing" + string_to_be_redacted)
+    logger.error(arbitrary)
+
+    assert len(handler.emitted_records) == 1
+    message = handler.emitted_records[0].getMessage()
+    assert string_to_be_redacted not in message
+    assert replace_string in message
+
+
+def test_exception_not_in_message():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+    logger = logging.getLogger(__name__)
+
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    logger.addHandler(handler)
+
+    try:
+        raise MemoryError("something bad: ", string_to_be_redacted)
+    except MemoryError:
+        logger.exception("Failed to do something")
+
+    assert len(handler.emitted_records) == 1
+    message = handler.emitted_records[0].getMessage()
+    assert string_to_be_redacted not in message
+    assert replace_string in message
+
+
+def test_exc_text_redaction():
+    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    replace_string = "-#sensitive#-"
+    string_to_be_redacted = "172.24.41.42"
+
+    record = makeLogRecord(
+        {
+            'name': 'my.package.logger',
+            'msg': 'Connect by IP 172.24.41.42',
+            'exc_text': 'something 192.168.0.1 something'
+        }
+    )
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler.addFilter(
+        RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
+    )
+    handler.handle(record)
+
+    assert len(handler.emitted_records) == 1
+    exc_text = handler.emitted_records[0].exc_text
+    assert string_to_be_redacted not in exc_text
+    assert replace_string in exc_text
+
+
+def test_filter_bypass():
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+    record = makeLogRecord(
+        {
+            "name": "my.package.logger",
+            "msg": "Attempted connect to %s failed %d times",
+            "args": ("web.service", 42),
+        }
+    )
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
+    handler.addFilter(RegexRedactFilter(filter_regex=regex))
+    handler.handle(record)
+
+    assert len(handler.emitted_records) == 1
+    log_record = handler.emitted_records[0]
+    assert "Attempted connect to web.service failed 42 times" == log_record.getMessage()
+    assert ("web.service", 42) == log_record.args
+
+
+class SomeClass:
+    """
+    generic helper class
+    """
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+    def __repr__(self):
+        return self.message

--- a/tests/test_filter_handler.py
+++ b/tests/test_filter_handler.py
@@ -3,7 +3,7 @@ from logging import makeLogRecord
 
 from cee_syslog_handler import NamedCeeLogger, RegexFilter, RegexRedactFilter
 
-_DUMMY_HOST = ('localhost', 1337)
+_DUMMY_HOST = ("localhost", 1337)
 _DUMMY_PROTOCOL = 2
 
 
@@ -18,36 +18,37 @@ class CollectingNamedCeeLogger(NamedCeeLogger):
 
 
 def test_filter():
-    filter_regex = r'/health|/metrics'
+    filter_regex = r"/health|/metrics"
 
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(RegexFilter(filter_regex))
 
-    handler.handle(makeLogRecord({'msg': 'POST /important/endpoint 200 OK'}))
-    assert len(handler.emitted_records) == 1 # record emitted
+    handler.handle(makeLogRecord({"msg": "POST /important/endpoint 200 OK"}))
+    assert len(handler.emitted_records) == 1  # record emitted
 
-    handler.handle(makeLogRecord({'msg': 'GET /health 200 OK'}))
-    assert len(handler.emitted_records) == 1 # no new record emitted
+    handler.handle(makeLogRecord({"msg": "GET /health 200 OK"}))
+    assert len(handler.emitted_records) == 1  # no new record emitted
 
-    handler.handle(makeLogRecord({'msg': 'GET /metrics 404'}))
-    assert len(handler.emitted_records) == 1 # no new record emitted
+    handler.handle(makeLogRecord({"msg": "GET /metrics 404"}))
+    assert len(handler.emitted_records) == 1  # no new record emitted
 
-    handler.handle(makeLogRecord({'msg': 'Eating vegetables is healthy and improves blood metrics'}))
-    assert len(handler.emitted_records) == 2 # new record emitted
+    handler.handle(
+        makeLogRecord(
+            {"msg": "Eating vegetables is healthy and improves blood metrics"}
+        )
+    )
+    assert len(handler.emitted_records) == 2  # new record emitted
 
 
 def test_redacting_filter():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
 
     record = makeLogRecord(
-        {
-            'name': 'my.package.logger',
-            'msg': 'Connect by IP 172.24.41.42'
-        }
+        {"name": "my.package.logger", "msg": "Connect by IP 172.24.41.42"}
     )
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -60,19 +61,19 @@ def test_redacting_filter():
 
 
 def test_redact_injected_variables():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
 
     arbitrary_object = SomeClass("some 172.24.41.42 arbitrary object")
     record = makeLogRecord(
         {
-            'name': 'my.package.logger',
-            'msg': 'Connect %d by IP %s %s',
-            'args': (42, '172.24.41.42', arbitrary_object)
+            "name": "my.package.logger",
+            "msg": "Connect %d by IP %s %s",
+            "args": (42, "172.24.41.42", arbitrary_object),
         }
     )
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -85,12 +86,12 @@ def test_redact_injected_variables():
 
 
 def test_redact_exception():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
     logger = logging.getLogger(__name__)
 
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -99,11 +100,7 @@ def test_redact_exception():
     arbitrary_object = SomeClass("some 172.24.41.42 arbitrary object")
 
     try:
-        raise MemoryError(
-            "something bad: ",
-            string_to_be_redacted,
-            arbitrary_object
-        )
+        raise MemoryError("something bad: ", string_to_be_redacted, arbitrary_object)
     except MemoryError as e:
         logger.exception(e)
 
@@ -114,12 +111,12 @@ def test_redact_exception():
 
 
 def test_redact_objects():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
 
     logger = logging.getLogger(__name__)
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -135,12 +132,12 @@ def test_redact_objects():
 
 
 def test_exception_not_in_message():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
     logger = logging.getLogger(__name__)
 
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -158,18 +155,18 @@ def test_exception_not_in_message():
 
 
 def test_exc_text_redaction():
-    regex = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
     replace_string = "-#sensitive#-"
     string_to_be_redacted = "172.24.41.42"
 
     record = makeLogRecord(
         {
-            'name': 'my.package.logger',
-            'msg': 'Connect by IP 172.24.41.42',
-            'exc_text': 'something 192.168.0.1 something'
+            "name": "my.package.logger",
+            "msg": "Connect by IP 172.24.41.42",
+            "exc_text": "something 192.168.0.1 something",
         }
     )
-    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, 'myname')
+    handler = CollectingNamedCeeLogger(_DUMMY_HOST, _DUMMY_PROTOCOL, "myname")
     handler.addFilter(
         RegexRedactFilter(filter_regex=regex, replace_string=replace_string)
     )
@@ -204,6 +201,7 @@ class SomeClass:
     """
     generic helper class
     """
+
     def __init__(self, message):
         self.message = message
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -6,7 +6,7 @@ from cee_syslog_handler import JsonFormatter
 
 def test_json_formatter():
     fmt = JsonFormatter()
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     res = fmt.format(record)
 
     assert '"facility": "my.package.logger' in res
@@ -19,7 +19,7 @@ def test_json_formatter():
 
 def test_json_formatter_options():
     fmt = JsonFormatter(debugging_fields=False)
-    record = makeLogRecord( {'name':'my.package.logger', 'special_field': 10} )
+    record = makeLogRecord({"name": "my.package.logger", "special_field": 10})
     res = fmt.format(record)
 
     d = json.loads(res)
@@ -29,15 +29,15 @@ def test_json_formatter_options():
 
     assert d["_special_field"] == 10
 
-    fmt = JsonFormatter(datefmt='%Y-%m-%d',)
-    record = makeLogRecord( {'name':'my.package.logger', 'special_field': 10} )
+    fmt = JsonFormatter(datefmt="%Y-%m-%d",)
+    record = makeLogRecord({"name": "my.package.logger", "special_field": 10})
     res = fmt.format(record)
 
     d = json.loads(res)
     assert len(d["timestamp"]) == 10
 
     fmt = JsonFormatter(extra_fields=False)
-    record = makeLogRecord( {'name':'my.package.logger', 'special_field': 10} )
+    record = makeLogRecord({"name": "my.package.logger", "special_field": 10})
     res = fmt.format(record)
 
     d = json.loads(res)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -4,22 +4,22 @@ from cee_syslog_handler import CeeSysLogHandler
 
 
 def test_default_facility():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     handler = CeeSysLogHandler()
 
     assert '"facility": "my.package.logger"' in handler.format(record)
 
 
 def test_custom_facility():
-    record = makeLogRecord( {'name':'my.package.logger'} )
-    handler = CeeSysLogHandler(facility='my.custom.facility')
+    record = makeLogRecord({"name": "my.package.logger"})
+    handler = CeeSysLogHandler(facility="my.custom.facility")
 
     assert '"facility": "my.custom.facility"' in handler.format(record)
     assert '"_logger": "my.package.logger"' in handler.format(record)
 
 
 def test_custom_field():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     record.custom_field = "custom value"
     handler = CeeSysLogHandler()
 
@@ -27,7 +27,7 @@ def test_custom_field():
 
 
 def test_custom_field_with_leading_underscore():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     record._custom_field = "custom value"
     handler = CeeSysLogHandler()
 
@@ -35,31 +35,31 @@ def test_custom_field_with_leading_underscore():
 
 
 def test_custom_fields_with_underscores_have_precendence():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     record.foo = "should not appear in output"
     record._foo = "has precedence"
     handler = CeeSysLogHandler()
 
-    assert 'has precedence' in handler.format(record)
-    assert 'should not appear in output' not in handler.format(record)
+    assert "has precedence" in handler.format(record)
+    assert "should not appear in output" not in handler.format(record)
 
 
 def test_static_field():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     handler = CeeSysLogHandler(custom=42)
 
     assert '"_custom": 42' in handler.format(record)
 
 
 def test_static_field_with_leading_underscore():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     handler = CeeSysLogHandler(_custom="foo")
 
     assert '"_custom": "foo"' in handler.format(record)
 
 
 def test_id_field_not_supported():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     record.id = "custom value"
     record._id = "some other value value"
     handler = CeeSysLogHandler()
@@ -73,8 +73,10 @@ class _BadStringRepresentation(object):
 
 
 def test_custom_field_with_raising_str():
-    record = makeLogRecord( {'name':'my.package.logger'} )
+    record = makeLogRecord({"name": "my.package.logger"})
     record._custom_field = _BadStringRepresentation()
     handler = CeeSysLogHandler()
 
-    assert '"_custom_field": "value could not be converted to str"' in handler.format(record)
+    assert '"_custom_field": "value could not be converted to str"' in handler.format(
+        record
+    )

--- a/tests/test_named_logger.py
+++ b/tests/test_named_logger.py
@@ -4,15 +4,16 @@ import logging
 
 from cee_syslog_handler import NamedCeeLogger
 
-
-_DUMMY_HOST = ('localhost', 1337)
+_DUMMY_HOST = ("localhost", 1337)
 _DUMMY_PROTOCOL = 2
 
 
 def _check_format_adds_service_name(expected_service_name):
     expected_json_field = '"_name": "{}"'.format(expected_service_name)
     logger = NamedCeeLogger(_DUMMY_HOST, 2, expected_service_name)
-    record = logging.LogRecord('dummy_logger', logging.DEBUG, 'test.py', 13, 'Dummy message', (), None)
+    record = logging.LogRecord(
+        "dummy_logger", logging.DEBUG, "test.py", 13, "Dummy message", (), None
+    )
 
     assert expected_json_field in logger.format(record)
 
@@ -21,5 +22,5 @@ def test_format_adds_service_name():
     """
     Ensure the Cee entry created by format contains the name provided to the logger constructor
     """
-    _check_format_adds_service_name('My Fancy Service')
-    _check_format_adds_service_name('Another Service')
+    _check_format_adds_service_name("My Fancy Service")
+    _check_format_adds_service_name("Another Service")


### PR DESCRIPTION
A redacting filter based on regex substitution is added.
This filter modifies `msg` and `args` of a log record and is configurable with a custom replacement string and regex.